### PR TITLE
refine recite page styles

### DIFF
--- a/styles/Poem.module.css
+++ b/styles/Poem.module.css
@@ -93,6 +93,10 @@
   text-indent: 2em;
 }
 
+.contentClassical .translation {
+  text-indent: 2em;
+}
+
 .poemLine {
   margin: 1rem 0;
   position: relative;
@@ -147,6 +151,17 @@
 .translationToggle:hover {
   background-color: var(--primary);
   transform: translateY(-2px);
+}
+
+.translationToggle:active {
+  transform: translateY(0);
+  filter: brightness(0.9);
+  color: white;
+}
+
+.translationToggle:visited {
+  background-color: var(--accent);
+  color: white;
 }
 
 .footer {
@@ -209,7 +224,6 @@
   }
   
   .translation {
-    display: block !important;
     page-break-inside: avoid;
   }
   

--- a/styles/Recite.module.css
+++ b/styles/Recite.module.css
@@ -206,8 +206,6 @@
     background-color: var(--background);
     border-radius: var(--radius);
     padding: 1.2rem; /* 减少内边距 */
-    max-height: 500px;
-    overflow-y: auto;
 }
 
 /* 新增：诗句展示区域，不限制在框内 */
@@ -370,6 +368,50 @@
     transform: translateY(-2px);
 }
 
+.dangerButton {
+    background-color: var(--button-danger);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 1rem;
+    transition: var(--transition);
+}
+
+.dangerButton:hover {
+    filter: brightness(0.9);
+    transform: translateY(-2px);
+}
+
+.startButton {
+    background-color: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.6rem 1.5rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 1rem;
+    display: block;
+    margin: 1rem auto 0;
+    transition: var(--transition);
+}
+
+.startButton:hover {
+    background-color: var(--primary);
+    transform: translateY(-2px);
+}
+
+.controlButton:active,
+.primaryButton:active,
+.secondaryButton:active,
+.finishButton:active,
+.startButton:active,
+.dangerButton:active {
+    transform: translateY(0);
+    filter: brightness(0.9);
+}
+
 .history {
     margin-top: 2rem;
     padding-top: 1rem;
@@ -473,6 +515,11 @@
     color: transparent;
     border-bottom: 1px solid var(--text-light);
     margin: 0 2px;
+}
+
+.hidden::selection {
+    background-color: var(--accent);
+    color: transparent;
 }
 
 .placeholder {
@@ -674,7 +721,6 @@
 
     .reciteAllContent,
     .readthroughMode {
-        max-height: 400px;
         padding: 1rem;
     }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -135,6 +135,11 @@ a:hover {
     color: var(--accent);
 }
 
+button,
+a {
+    -webkit-tap-highlight-color: transparent;
+}
+
 /* 文本选择样式 */
 ::selection {
     background-color: var(--accent);


### PR DESCRIPTION
## Summary
- style recite start and danger buttons with consistent theme
- keep hidden text concealed when selected and add active button feedback
- remove fixed height limits so recite containers expand with content and eliminate tap highlight flash

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5a3bab200832da49824838cd3a49e