### PR TITLE
refine recite page styles and printing

### DIFF
--- a/styles/Poem.module.css
+++ b/styles/Poem.module.css
@@ -39,6 +39,12 @@
   transform: translateX(-5px);
 }
 
+.homeButton:visited,
+.homeButton:active {
+  background-color: var(--background);
+  color: var(--primary);
+}
+
 .title {
   font-size: 2rem;
   text-align: center;
@@ -90,6 +96,10 @@
 
 /* 文言文和词的首行缩进 */
 .contentClassical .poemLine {
+  text-indent: 2em;
+}
+
+.contentClassical .translation {
   text-indent: 2em;
 }
 
@@ -149,6 +159,17 @@
   transform: translateY(-2px);
 }
 
+.translationToggle:active {
+  transform: translateY(0);
+  filter: brightness(0.9);
+  color: white;
+}
+
+.translationToggle:visited {
+  background-color: var(--accent);
+  color: white;
+}
+
 .footer {
   text-align: center;
   padding: 2rem 0;
@@ -175,23 +196,34 @@
 
 @media screen and (max-width: 768px) {
   .container {
-    padding: 1.5rem;
-    margin: 1rem 0.5rem;
-    /* 减少移动端边距 */
+    padding: 1rem;
+    margin: 0.5rem 0.25rem;
+    /* 进一步压缩移动端边距 */
   }
 
   .title {
-    font-size: 1.8rem;
+    font-size: 1.6rem;
   }
 
   .contentClassical,
   .content {
-    padding: 1rem;
+    padding: 0.75rem;
+    line-height: 1.6;
+  }
+
+  .poemLine {
+    margin: 0.6rem 0;
+  }
+
+  .translation {
+    margin-top: 0.3rem;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
   }
 
   .translationToggle {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.8rem;
   }
 }
 
@@ -209,7 +241,6 @@
   }
   
   .translation {
-    display: block !important;
     page-break-inside: avoid;
   }
   

--- a/styles/Recite.module.css
+++ b/styles/Recite.module.css
@@ -206,8 +206,6 @@
     background-color: var(--background);
     border-radius: var(--radius);
     padding: 1.2rem; /* 减少内边距 */
-    max-height: 500px;
-    overflow-y: auto;
 }
 
 /* 新增：诗句展示区域，不限制在框内 */
@@ -253,6 +251,12 @@
     background-color: var(--accent);
     color: white;
     transform: translateX(-5px);
+}
+
+.backButton:visited,
+.backButton:active {
+    background-color: var(--background);
+    color: var(--primary);
 }
 
 .title {
@@ -370,6 +374,56 @@
     transform: translateY(-2px);
 }
 
+.secondaryButton:visited,
+.secondaryButton:active {
+    background-color: var(--background);
+    color: var(--text);
+}
+
+.dangerButton {
+    background-color: var(--button-danger);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 1rem;
+    transition: var(--transition);
+}
+
+.dangerButton:hover {
+    filter: brightness(0.9);
+    transform: translateY(-2px);
+}
+
+.startButton {
+    background-color: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.6rem 1.5rem;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 1rem;
+    display: block;
+    margin: 1rem auto 0;
+    transition: var(--transition);
+}
+
+.startButton:hover {
+    background-color: var(--primary);
+    transform: translateY(-2px);
+}
+
+.controlButton:active,
+.primaryButton:active,
+.secondaryButton:active,
+.finishButton:active,
+.startButton:active,
+.dangerButton:active {
+    transform: translateY(0);
+    filter: brightness(0.9);
+}
+
 .history {
     margin-top: 2rem;
     padding-top: 1rem;
@@ -473,6 +527,11 @@
     color: transparent;
     border-bottom: 1px solid var(--text-light);
     margin: 0 2px;
+}
+
+.hidden::selection {
+    background-color: var(--accent);
+    color: transparent;
 }
 
 .placeholder {
@@ -593,22 +652,24 @@
 /* 响应式调整 */
 @media screen and (max-width: 768px) {
     .reciteContainer {
-        margin: 1rem 0.5rem;
-        padding: 1.5rem;
+        margin: 0.5rem 0.25rem;
+        padding: 1rem;
     }
 
     .title {
-        font-size: 1.8rem;
+        font-size: 1.6rem;
     }
 
     .buttonGroup {
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.4rem;
     }
 
-    .reciteControls {
+    .reciteControls,
+    .controlButtons {
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.4rem;
+        align-items: stretch;
     }
 
     .hintButton,
@@ -616,11 +677,34 @@
         width: 100%;
     }
 
+    .lineWithTranslation {
+        margin: 0.4rem 0;
+    }
+
+    .originalLine,
+    .hiddenLine,
+    .specialFormatText {
+        font-size: 1rem;
+        line-height: 1.35;
+    }
+
+    .translationLine {
+        font-size: 0.8rem;
+        padding: 0.15rem 0.5rem;
+    }
+
+    .reciteAllContent,
+    .readthroughMode {
+        padding: 0.8rem;
+    }
+
     .fullReveal,
     .partialReveal,
     .firstCharReveal,
-    .noReveal {
-        font-size: 1.1rem;
+    .noReveal,
+    .activeLine {
+        font-size: 1rem;
+        line-height: 1.4;
     }
 }
 
@@ -649,32 +733,4 @@
     margin: 0.4rem 0; /* 减少上下边距 */
     text-align: center;
     font-family: "Noto Serif SC", "Source Han Serif SC", "Source Han Serif CN", STSong, "SimSun", "宋体", serif;
-}
-
-/* 响应式调整 */
-@media screen and (max-width: 768px) {
-    .reciteContainer {
-        margin: 1rem 0.5rem;
-        padding: 1.5rem;
-    }
-
-    .controlButtons {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .originalLine,
-    .hiddenLine {
-        font-size: 1rem;
-    }
-
-    .translationLine {
-        font-size: 0.8rem;
-    }
-
-    .reciteAllContent,
-    .readthroughMode {
-        max-height: 400px;
-        padding: 1rem;
-    }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -135,6 +135,11 @@ a:hover {
     color: var(--accent);
 }
 
+button,
+a {
+    -webkit-tap-highlight-color: transparent;
+}
+
 /* 文本选择样式 */
 ::selection {
     background-color: var(--accent);
@@ -278,6 +283,10 @@ a:hover {
 
 /* 响应式调整 */
 @media screen and (max-width: 768px) {
+    body {
+        line-height: 1.5;
+    }
+
     .container {
         padding: 1rem;
     }


### PR DESCRIPTION
## Summary
- compress mobile spacing and line heights for poem and recitation views
- add active/visited styles so home, back and secondary buttons maintain theme colors
- lower global line-height on small screens for denser content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5a3bab200832da49824838cd3a49e