### PR TITLE
Refine mobile layout and spacing

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -244,19 +244,26 @@
 
 @media screen and (max-width: 768px) {
     .container {
-        padding: 1rem;
+        padding: 0.75rem;
     }
 
     .title {
-        font-size: 2.2rem;
+        font-size: 2rem;
+        margin: 1.2rem 0;
     }
 
     .poemList {
         grid-template-columns: 1fr;
+        gap: 1rem;
+        margin: 1rem 0;
+    }
+
+    .searchContainer {
+        margin: 1rem auto;
     }
 
     .searchInput {
-        padding: 0.8rem 1.2rem;
+        padding: 0.7rem 1rem;
     }
 }
 

--- a/styles/Poem.module.css
+++ b/styles/Poem.module.css
@@ -190,23 +190,34 @@
 
 @media screen and (max-width: 768px) {
   .container {
-    padding: 1.5rem;
-    margin: 1rem 0.5rem;
-    /* 减少移动端边距 */
+    padding: 1rem;
+    margin: 0.75rem 0.25rem;
+    /* 进一步减少移动端边距 */
   }
 
   .title {
-    font-size: 1.8rem;
+    font-size: 1.6rem;
+    margin-bottom: 0.5rem;
   }
 
   .contentClassical,
   .content {
-    padding: 1rem;
+    padding: 0.75rem;
+    margin: 1rem 0;
+    line-height: 1.6;
+  }
+
+  .poemLine {
+    margin: 0.5rem 0;
+  }
+
+  .showPinyin {
+    line-height: 2.2;
   }
 
   .translationToggle {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.8rem;
   }
 }
 

--- a/styles/Recite.module.css
+++ b/styles/Recite.module.css
@@ -640,12 +640,12 @@
 /* 响应式调整 */
 @media screen and (max-width: 768px) {
     .reciteContainer {
-        margin: 1rem 0.5rem;
-        padding: 1.5rem;
+        margin: 0.75rem 0.25rem;
+        padding: 1rem;
     }
 
     .title {
-        font-size: 1.8rem;
+        font-size: 1.6rem;
     }
 
     .buttonGroup {
@@ -701,8 +701,8 @@
 /* 响应式调整 */
 @media screen and (max-width: 768px) {
     .reciteContainer {
-        margin: 1rem 0.5rem;
-        padding: 1.5rem;
+        margin: 0.75rem 0.25rem;
+        padding: 1rem;
     }
 
     .controlButtons {
@@ -721,6 +721,6 @@
 
     .reciteAllContent,
     .readthroughMode {
-        padding: 1rem;
+        padding: 0.75rem;
     }
 }

--- a/styles/ReciteProgress.module.css
+++ b/styles/ReciteProgress.module.css
@@ -247,25 +247,26 @@
 /* 响应式调整 */
 @media screen and (max-width: 768px) {
     .progressContainer {
-        margin: 1rem 0.5rem;
-        padding: 1.5rem;
+        margin: 0.75rem 0.25rem;
+        padding: 1rem;
     }
 
     .title {
-        font-size: 1.8rem;
+        font-size: 1.6rem;
+        margin: 1rem 0;
     }
 
     .statsCards {
         grid-template-columns: 1fr;
-        gap: 0.75rem;
+        gap: 0.5rem;
     }
 
     .statCard {
-        padding: 1rem;
+        padding: 0.75rem;
     }
 
     .statValue {
-        font-size: 1.5rem;
+        font-size: 1.4rem;
     }
 
     .poemProgress {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -284,6 +284,15 @@ a {
 /* 响应式调整 */
 @media screen and (max-width: 768px) {
     .container {
-        padding: 1rem;
+        padding: 0.75rem;
+    }
+
+    body {
+        line-height: 1.5;
+    }
+
+    .page-title {
+        margin: 1.2rem 0;
+        font-size: 2rem;
     }
 }


### PR DESCRIPTION
## Summary
- tighten global mobile styles with smaller container padding and reduced line height for better use of space
- streamline poem and home pages' mobile spacing and typography to show more content
- adjust recite views and progress pages with compact margins for handheld readability

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68c5b1c1c738832d81f126bba79b5330